### PR TITLE
Add input for choosing CI pipeline in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,14 @@
 name: Deploy to server
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      web_id:
+        description: Number of desired CI pipeline
+        default: "latest"
+        type: string
+
+
 
 jobs:
   deploy-on-shi:
@@ -19,5 +27,6 @@ jobs:
           script: |
             cd kontraktor/
             docker compose down
+            sed -i 's/\(export WEB_ID=\).*/\1${{ inputs.web_id }}/' .env
             docker compose pull
             docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   web:
     container_name: demo-web
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
-    image: cechpetr/kontraktor:18
+    image: "cechpetr/kontraktor:${WEB_ID:-latest}"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
This commit introduces an input to the Continuous Deployment workflow for choosing a specific CI pipeline. The pipeline number is now an adjustable parameter in the GitHub Actions workflow. Also, it updates the Docker image used in the docker-compose.yml file to accept the pipeline number,