### PR TITLE
Update tags in GitHub Actions workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: cechpetr/kontraktor:${{ github.run_number }}
+          tags: |
+            cechpetr/kontraktor:${{ github.run_number }}
+            cechpetr/kontraktor:latest


### PR DESCRIPTION
Modified the tagging strategy of Docker images in .github/workflows/ci.yml. In addition to tagging the image with the current GitHub run number, it now