### PR TITLE
Remove web-entrypoint.sh and update Dockerfile and GitHub actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,8 +8,6 @@ on:
         default: "latest"
         type: string
 
-
-
 jobs:
   deploy-on-shi:
     name: Deploy on devel server
@@ -30,3 +28,8 @@ jobs:
             sed -i 's/\(export WEB_ID=\).*/\1${{ inputs.web_id }}/' .env
             docker compose pull
             docker compose up -d
+            docker compose exec web python manage.py migrate --noinput
+            docker compose exec web python manage.py collectstatic --noinput
+            docker compose exec web python manage.py createsuperuser --noinput --username=${{ secrets.SUP_USER}}  --email=${{ secrets.SUP_EMAIL }}
+#            docker compose exec web python manage.py compilemessages --noinput
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,5 @@ RUN apt-get update \
 
 RUN pip install --upgrade pip setuptools wheel
 
-COPY app/requirements.txt .
-RUN pip install -r requirements.txt
-
-COPY /app .
-
-WORKDIR .
-
-COPY ./web-entrypoint.sh /
-ENTRYPOINT ["sh", "/web-entrypoint.sh"]
-
-#CMD ["gunicorn", "-c", "python:config.gunicorn", "config.wsgi"]
+COPY app .
+RUN pip install -r app/requirements.txt

--- a/web-entrypoint.sh
+++ b/web-entrypoint.sh
@@ -1,7 +1,0 @@
-#?/bin/sh
-
-python manage.py migrate --no-input
-python manage.py collectstatic --no-input
-
-DJANGO_SUPERUSER_PASSWORD=12345 python manage.py createsuperuser --no-input --username=petr  --email=petr@cechpetr.cz
-#gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 4


### PR DESCRIPTION
Removed web-entrypoint.sh and related references in Dockerfile, replacing its functionality with commands embedded directly in the GitHub actions workflow file (cd.yml). This eliminates the need for an entrypoint script and streamlines the project setup process. Dockerfile also updated to only copy the app directory and install requirements from within it.