### PR TITLE
Update Dockerfile copy statement and pip install directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ RUN apt-get update \
 
 RUN pip install --upgrade pip setuptools wheel
 
-COPY app .
-RUN pip install -r app/requirements.txt
+COPY app .app
+RUN pip install -r .app/requirements.txt


### PR DESCRIPTION
The Dockerfile copy statement is updated to copy the app directory to a .app directory within the Docker container. Following that change, the pip install command now references this new .app directory to install Python requirements. This change rationalizes the project structure within the Docker container.